### PR TITLE
Adds comprehensive report generation and AI prompt export capabilities to vercel-doctor.

### DIFF
--- a/packages/vercel-doctor/README.md
+++ b/packages/vercel-doctor/README.md
@@ -66,16 +66,19 @@ Supports Cursor, Claude Code, Amp Code, Codex, Gemini CLI, OpenCode, Windsurf, a
 Usage: vercel-doctor [directory] [options]
 
 Options:
-  -v, --version     display the version number
-  --no-lint         skip linting
-  --no-dead-code    skip dead code detection
-  --verbose         show file details per rule
-  --score           output only the score
-  -y, --yes         skip prompts, scan all workspace projects
-  --project <name>  select workspace project (comma-separated for multiple)
-  --diff [base]     scan only files changed vs base branch
-  --offline         skip telemetry (anonymous, not stored, only used to calculate score)
-  -h, --help        display help for command
+  -v, --version         display the version number
+  --no-lint             skip linting
+  --no-dead-code        skip dead code detection
+  --verbose             show file details per rule
+  --score               output only the score
+  -y, --yes             skip prompts, scan all workspace projects
+  --project <name>      select workspace project (comma-separated for multiple)
+  --diff [base]         scan only files changed vs base branch
+  --offline             skip telemetry (anonymous, not stored, only used to calculate score)
+  --output <format>     output format: "human" (default), "json", or "markdown"
+  --report <file>       write human-readable report to file
+  --ai-prompts <file>   write AI fix prompts to JSON file for use with Cursor/Claude/Windsurf
+  -h, --help            display help for command
 ```
 
 ## Configuration
@@ -117,6 +120,46 @@ If both exist, `vercel-doctor.config.json` takes precedence.
 | `diff`         | `boolean \| string` | —       | Force diff mode (`true`) or pin a base branch (`"main"`). Set to `false` to disable auto-detection.                                |
 
 CLI flags always override config values.
+
+## Report Generation & AI Prompts
+
+Generate detailed reports and AI-compatible fix prompts:
+
+```bash
+# Generate a markdown report
+npx vercel-doctor . --output markdown --report report.md
+
+# Export AI prompts for fixing issues (use with Cursor, Claude, Windsurf)
+npx vercel-doctor . --ai-prompts fixes.json
+```
+
+The `--ai-prompts` flag generates ready-to-use prompts for AI coding tools. The format is auto-detected from the file extension:
+
+- **`.json`** - Structured format for programmatic use and automation
+- **`.md` or `.markdown`** - Human-readable format, easy to copy-paste into AI chats
+
+```bash
+# Export as JSON (for scripts, automation)
+npx vercel-doctor . --ai-prompts fixes.json
+
+# Export as Markdown (for manual copy-paste into Cursor/Claude/Windsurf)
+npx vercel-doctor . --ai-prompts fixes.md
+```
+
+Each prompt includes:
+
+- The specific rule violation
+- File location and line number
+- Before/after code examples
+- Step-by-step fix instructions
+
+Example AI prompt output:
+
+```json
+{
+  "vercel-doctor/vercel-no-force-dynamic::src/app/page.tsx:15": "Fix this Vercel optimization issue..."
+}
+```
 
 ## Node.js API
 

--- a/packages/vercel-doctor/src/cli.ts
+++ b/packages/vercel-doctor/src/cli.ts
@@ -22,6 +22,9 @@ interface CliFlags {
   offline: boolean;
   project?: string;
   diff?: boolean | string;
+  output?: "human" | "json" | "markdown";
+  report?: string;
+  aiPrompts?: string;
 }
 
 const exitWithFixHint = () => {
@@ -83,6 +86,12 @@ const program = new Command()
   .option("--project <name>", "select workspace project (comma-separated for multiple)")
   .option("--diff [base]", "scan only files changed vs base branch")
   .option("--offline", "skip telemetry (anonymous, not stored, only used to calculate score)")
+  .option("--output <format>", 'output format: "human" (default), "json", or "markdown"')
+  .option("--report <file>", "write human-readable report to file")
+  .option(
+    "--ai-prompts <file>",
+    "write AI fix prompts to JSON file for use with Cursor/Claude/Windsurf",
+  )
   .action(async (directory: string, flags: CliFlags) => {
     const isScoreOnly = flags.score;
 
@@ -106,6 +115,9 @@ const program = new Command()
         verbose: isCliOverride("verbose") ? Boolean(flags.verbose) : (userConfig?.verbose ?? false),
         scoreOnly: isScoreOnly,
         offline: flags.offline,
+        output: flags.output ?? "human",
+        reportFile: flags.report,
+        aiPromptsFile: flags.aiPrompts,
       };
 
       const isAutomatedEnvironment = [

--- a/packages/vercel-doctor/src/types.ts
+++ b/packages/vercel-doctor/src/types.ts
@@ -103,8 +103,6 @@ export interface ScanOptions {
   offline?: boolean;
   includePaths?: string[];
   output?: "human" | "json" | "markdown";
-  reportFile?: string;
-  aiPromptsFile?: string;
 }
 
 export interface DiffInfo {

--- a/packages/vercel-doctor/src/types.ts
+++ b/packages/vercel-doctor/src/types.ts
@@ -102,6 +102,9 @@ export interface ScanOptions {
   scoreOnly?: boolean;
   offline?: boolean;
   includePaths?: string[];
+  output?: "human" | "json" | "markdown";
+  reportFile?: string;
+  aiPromptsFile?: string;
 }
 
 export interface DiffInfo {

--- a/packages/vercel-doctor/src/utils/generate-report.ts
+++ b/packages/vercel-doctor/src/utils/generate-report.ts
@@ -1,0 +1,444 @@
+import type { Diagnostic } from "../types.js";
+
+export interface ReportSection {
+  title: string;
+  diagnostics: Diagnostic[];
+  description: string;
+  impact: string;
+}
+
+export interface FixSuggestion {
+  title: string;
+  before: string;
+  after: string;
+  explanation: string;
+}
+
+export interface AIPromptContext {
+  rule: string;
+  issue: string;
+  filePath: string;
+  line: number;
+  severity: "error" | "warning";
+  fixStrategy: string;
+}
+
+const CATEGORY_DESCRIPTIONS: Record<string, { description: string; impact: string }> = {
+  Vercel: {
+    description: "Configuration and deployment patterns that affect Vercel billing and performance",
+    impact: "May increase function execution time, bandwidth costs, or build times",
+  },
+  Performance: {
+    description: "JavaScript/TypeScript code patterns that impact runtime performance",
+    impact: "May increase function duration and compute costs",
+  },
+  "Dead Code": {
+    description: "Unused files, exports, types, and dependencies",
+    impact: "Increases bundle size and cold start times",
+  },
+  "Next.js": {
+    description: "Next.js-specific patterns affecting caching, rendering, and optimization",
+    impact: "May reduce cache hit rates and increase server load",
+  },
+};
+
+const RULE_FIX_STRATEGIES: Record<string, FixSuggestion> = {
+  "vercel-no-force-dynamic": {
+    title: "Replace force-dynamic with revalidate",
+    before: "export const dynamic = 'force-dynamic'",
+    after: "export const revalidate = 3600 // or use cache: 'force-cache' in fetch",
+    explanation:
+      "Use incremental static regeneration (ISR) or cacheable fetches instead of forcing dynamic rendering",
+  },
+  "vercel-no-no-store-fetch": {
+    title: "Add caching to fetch calls",
+    before: "fetch(url, { cache: 'no-store' })",
+    after: "fetch(url, { cache: 'force-cache', next: { revalidate: 3600 } })",
+    explanation:
+      "Use cacheable fetches with revalidation instead of no-store for data that doesn't need to be real-time",
+  },
+  "vercel-prefer-get-static-props": {
+    title: "Convert getServerSideProps to getStaticProps",
+    before: "export async function getServerSideProps() { ... }",
+    after: "export async function getStaticProps() { ... } // Add revalidate for ISR",
+    explanation: "Use static generation with ISR instead of server-side rendering when possible",
+  },
+  "vercel-get-static-props-consider-isr": {
+    title: "Add ISR to getStaticProps",
+    before: "export async function getStaticProps() { return { props: {} } }",
+    after: "export async function getStaticProps() { return { props: {}, revalidate: 3600 } }",
+    explanation: "Add revalidation to enable ISR and reduce build times for large sites",
+  },
+  "vercel-edge-heavy-import": {
+    title: "Move heavy imports to Node runtime",
+    before: "import { heavy } from 'heavy-module' // in edge runtime",
+    after: "// Move to Node.js runtime handler or use dynamic import",
+    explanation: "Heavy modules should run in Node.js runtime, not edge",
+  },
+  "vercel-edge-sequential-await": {
+    title: "Parallelize independent awaits",
+    before: "const a = await fetchA();\nconst b = await fetchB();",
+    after: "const [a, b] = await Promise.all([fetchA(), fetchB()]);",
+    explanation: "Use Promise.all() to run independent async operations in parallel",
+  },
+  "vercel-missing-cache-policy": {
+    title: "Add Cache-Control headers",
+    before: "return Response.json(data)",
+    after: "return Response.json(data, { headers: { 'Cache-Control': 's-maxage=3600' } })",
+    explanation: "Add explicit cache headers to enable CDN caching for API responses",
+  },
+  "vercel-image-global-unoptimized": {
+    title: "Enable image optimization",
+    before: "images: { unoptimized: true }",
+    after: "images: { remotePatterns: [{ hostname: 'example.com' }] }",
+    explanation: "Remove unoptimized flag and configure domains for Vercel Image Optimization",
+  },
+  "vercel-image-remote-pattern-too-broad": {
+    title: "Restrict remotePatterns pathname",
+    before: "{ hostname: 'cdn.example.com', pathname: '/**' }",
+    after: "{ hostname: 'cdn.example.com', pathname: '/images/**' }",
+    explanation: "Use specific path patterns instead of broad wildcards to prevent abuse",
+  },
+  "vercel-image-svg-without-unoptimized": {
+    title: "Add unoptimized for SVG",
+    before: "<Image src='/icon.svg' width={32} height={32} />",
+    after: "<Image src='/icon.svg' width={32} height={32} unoptimized />",
+    explanation: "SVGs don't benefit from image optimization, so mark them as unoptimized",
+  },
+  "vercel-suggest-turbopack-build-cache": {
+    title: "Enable Turbopack build cache",
+    before: "experimental: { ... }",
+    after: "experimental: { turbopackFileSystemCacheForBuild: true }",
+    explanation: "Enable Turbopack file system cache to reduce build times (Next.js 16+)",
+  },
+  "vercel-sequential-database-await": {
+    title: "Parallelize database queries",
+    before: "const user = await db.user.findUnique();\nconst posts = await db.post.findMany();",
+    after:
+      "const [user, posts] = await Promise.all([\n  db.user.findUnique(),\n  db.post.findMany()\n]);",
+    explanation: "Use Promise.all() for independent database queries to reduce function duration",
+  },
+  "vercel-consider-bun-runtime": {
+    title: "Switch to Bun runtime",
+    before: "// Using Node.js",
+    after: "{ 'packageManager': 'bun@1.x' } // in package.json",
+    explanation: "Configure Bun runtime in package.json for faster installs and builds",
+  },
+  "vercel-avoid-platform-cron": {
+    title: "Move cron to GitHub Actions or Cloudflare",
+    before: "{ 'crons': [{ 'path': '/api/cron', 'schedule': '0 0 * * *' }] }",
+    after: "// Use GitHub Actions scheduled workflows instead",
+    explanation: "Move scheduled jobs to external services to reduce Vercel function invocations",
+  },
+  "vercel-consider-fluid-compute": {
+    title: "Evaluate Fluid Compute",
+    before: "// Standard Node.js runtime",
+    after: "// Enable Fluid Compute in project settings for variable latency workloads",
+    explanation: "Consider Fluid Compute for workloads with variable latency or bursty traffic",
+  },
+  "vercel-large-static-asset": {
+    title: "Move assets to external CDN",
+    before: "// Large files in /public folder",
+    after: "// Upload to R2/S3 and serve via CDN",
+    explanation: "Move large static assets to external storage to reduce bandwidth costs",
+  },
+  "vercel-suggest-deploy-archive": {
+    title: "Use archive deployment",
+    before: "vercel deploy",
+    after: "vercel deploy --archive=tgz",
+    explanation: "Use archive deployment for large projects to avoid rate limits",
+  },
+  "vercel-missing-function-timeout": {
+    title: "Add maxDuration to function config",
+    before: `"functions": { "api/*.ts": { "runtime": "nodejs18.x" } }`,
+    after: `"functions": { "api/*.ts": { "runtime": "nodejs18.x", "maxDuration": 30 } }`,
+    explanation: "Add maxDuration (in seconds) to prevent runaway functions and control costs",
+  },
+  "async-parallel": {
+    title: "Parallelize sequential awaits",
+    before: "const a = await fetchA();\nconst b = await fetchB();\nconst c = await fetchC();",
+    after: "const [a, b, c] = await Promise.all([fetchA(), fetchB(), fetchC()]);",
+    explanation: "Run independent async operations in parallel to reduce total execution time",
+  },
+  "nextjs-no-client-fetch-for-server-data": {
+    title: "Move fetch to server component",
+    before: "'use client'\nuseEffect(() => { fetch('/api/data') }, [])",
+    after: "// Server component\nconst data = await fetch('/api/data')",
+    explanation: "Fetch data in server components instead of client-side useEffect",
+  },
+  "nextjs-link-prefetch-default": {
+    title: "Disable default prefetch",
+    before: "<Link href='/page'>Page</Link>",
+    after: "<Link href='/page' prefetch={false}>Page</Link>",
+    explanation: "Disable prefetch for non-critical links to reduce function invocations",
+  },
+  "nextjs-image-missing-sizes": {
+    title: "Add sizes prop to Image",
+    before: "<Image src='...' fill />",
+    after: "<Image src='...' fill sizes='(max-width: 768px) 100vw, 50vw' />",
+    explanation: "Add sizes attribute for responsive images to optimize download size",
+  },
+  "nextjs-no-side-effect-in-get-handler": {
+    title: "Move side effects to POST handler",
+    before: "export async function GET() { await db.update(); return Response.json({}) }",
+    after: "export async function POST() { await db.update(); return Response.json({}) }",
+    explanation: "Use POST for mutations to prevent CSRF and unintended prefetch triggers",
+  },
+  "server-after-nonblocking": {
+    title: "Wrap logging in after()",
+    before: "console.log('done'); analytics.track(event);",
+    after: "after(() => { console.log('done'); analytics.track(event); });",
+    explanation: "Use after() to run non-critical work after response is sent",
+  },
+};
+
+const formatDiagnosticForReport = (diagnostic: Diagnostic): string => {
+  const severityIcon = diagnostic.severity === "error" ? "✗" : "⚠";
+  const location = diagnostic.line > 0 ? `:${diagnostic.line}` : "";
+  return `  ${severityIcon} ${diagnostic.message}\n     at ${diagnostic.filePath}${location}`;
+};
+
+const generateAIPrompt = (context: AIPromptContext): string => {
+  const fixStrategy = RULE_FIX_STRATEGIES[context.rule];
+
+  return `Fix this Vercel optimization issue:
+
+**Rule:** ${context.rule}
+**File:** ${context.filePath}:${context.line}
+**Severity:** ${context.severity}
+**Issue:** ${context.issue}
+
+**Fix Strategy:**
+${fixStrategy?.explanation || context.fixStrategy}
+
+${
+  fixStrategy
+    ? `**Example:**
+\`\`\`
+// Before:
+${fixStrategy.before}
+
+// After:
+${fixStrategy.after}
+\`\`\``
+    : ""
+}
+
+Instructions:
+1. Locate the issue in the specified file
+2. Apply the suggested fix while maintaining existing functionality
+3. Ensure any imported types or dependencies remain valid
+4. Test that the change works as expected`;
+};
+
+export const groupDiagnosticsByCategory = (diagnostics: Diagnostic[]): ReportSection[] => {
+  const grouped = new Map<string, Diagnostic[]>();
+
+  for (const diagnostic of diagnostics) {
+    const category = diagnostic.category || "General";
+    const existing = grouped.get(category) ?? [];
+    existing.push(diagnostic);
+    grouped.set(category, existing);
+  }
+
+  return [...grouped.entries()].map(([category, categoryDiagnostics]) => {
+    const categoryInfo = CATEGORY_DESCRIPTIONS[category] ?? {
+      description: "General code quality issues",
+      impact: "May affect performance or maintainability",
+    };
+
+    return {
+      title: category,
+      diagnostics: categoryDiagnostics,
+      description: categoryInfo.description,
+      impact: categoryInfo.impact,
+    };
+  });
+};
+
+export const generateHumanReadableReport = (diagnostics: Diagnostic[]): string => {
+  if (diagnostics.length === 0) {
+    return `
+✅ No Vercel optimization issues found!
+
+Your project follows Vercel best practices for performance and cost optimization.
+`;
+  }
+
+  const sections = groupDiagnosticsByCategory(diagnostics);
+  const errorCount = diagnostics.filter((d) => d.severity === "error").length;
+  const warningCount = diagnostics.filter((d) => d.severity === "warning").length;
+
+  let report = `
+📊 Vercel Doctor Report
+═══════════════════════════════════════════════════════════════
+
+Summary: ${errorCount} errors, ${warningCount} warnings across ${diagnostics.length} issues
+
+`;
+
+  for (const section of sections) {
+    const errorCountInSection = section.diagnostics.filter((d) => d.severity === "error").length;
+    const warningCountInSection = section.diagnostics.filter(
+      (d) => d.severity === "warning",
+    ).length;
+
+    report += `\n${section.title} (${errorCountInSection} errors, ${warningCountInSection} warnings)\n`;
+    report += `${"─".repeat(section.title.length + 30)}\n`;
+    report += `Description: ${section.description}\n`;
+    report += `Impact: ${section.impact}\n\n`;
+
+    for (const diagnostic of section.diagnostics) {
+      report += formatDiagnosticForReport(diagnostic);
+      if (diagnostic.help) {
+        report += `\n     💡 ${diagnostic.help}`;
+      }
+      report += "\n\n";
+    }
+  }
+
+  return report;
+};
+
+export const generateAIPromptsMarkdown = (diagnostics: Diagnostic[]): string => {
+  const fixableDiagnostics = diagnostics.filter((d) => RULE_FIX_STRATEGIES[d.rule]);
+
+  if (fixableDiagnostics.length === 0) {
+    return "# AI Fix Prompts\n\nNo auto-fixable issues detected.\n";
+  }
+
+  let report = `# AI Fix Prompts for Vercel Doctor Issues\n\n`;
+  report += `**Generated:** ${new Date().toISOString()}\n\n`;
+  report += `> Copy any section below and paste it into Cursor, Claude, Windsurf, or other AI coding tools.\n\n`;
+  report += `---\n\n`;
+
+  for (const diagnostic of fixableDiagnostics) {
+    const fix = RULE_FIX_STRATEGIES[diagnostic.rule];
+    if (!fix) continue;
+
+    const location = diagnostic.line > 0 ? `:${diagnostic.line}` : "";
+
+    report += `## ${fix.title}\n\n`;
+    report += `- **File:** \`${diagnostic.filePath}${location}\`\n`;
+    report += `- **Rule:** \`${diagnostic.plugin}/${diagnostic.rule}\`\n`;
+    report += `- **Issue:** ${diagnostic.message}\n\n`;
+    report += `### Prompt\n\n`;
+    report += "\`\`\`\n";
+    report += generateAIPrompt({
+      rule: diagnostic.rule,
+      issue: diagnostic.message,
+      filePath: diagnostic.filePath,
+      line: diagnostic.line,
+      severity: diagnostic.severity,
+      fixStrategy: diagnostic.help,
+    });
+    report += "\n\`\`\`\n\n";
+    report += `---\n\n`;
+  }
+
+  return report;
+};
+
+export const generateAIPrompts = (diagnostics: Diagnostic[]): Map<string, string> => {
+  const prompts = new Map<string, string>();
+
+  for (const diagnostic of diagnostics) {
+    const key = `${diagnostic.plugin}/${diagnostic.rule}`;
+    const context: AIPromptContext = {
+      rule: diagnostic.rule,
+      issue: diagnostic.message,
+      filePath: diagnostic.filePath,
+      line: diagnostic.line,
+      severity: diagnostic.severity,
+      fixStrategy: diagnostic.help,
+    };
+
+    const prompt = generateAIPrompt(context);
+    prompts.set(`${key}::${diagnostic.filePath}:${diagnostic.line}`, prompt);
+  }
+
+  return prompts;
+};
+
+export const generateFixableIssuesReport = (diagnostics: Diagnostic[]): string => {
+  const fixableDiagnostics = diagnostics.filter((d) => RULE_FIX_STRATEGIES[d.rule]);
+
+  if (fixableDiagnostics.length === 0) {
+    return "\nNo auto-fixable issues detected.\n";
+  }
+
+  let report = `
+🔧 Auto-Fixable Issues (${fixableDiagnostics.length} issues)
+═══════════════════════════════════════════════════════════════
+
+These issues have known fix patterns that can be applied automatically:\n`;
+
+  for (const diagnostic of fixableDiagnostics) {
+    const fix = RULE_FIX_STRATEGIES[diagnostic.rule];
+    if (!fix) continue;
+
+    report += `\n${fix.title}\n`;
+    report += `${"─".repeat(fix.title.length)}\n`;
+    report += `File: ${diagnostic.filePath}:${diagnostic.line}\n`;
+    report += `Issue: ${diagnostic.message}\n\n`;
+    report += `Suggested change:\n`;
+    report += `  Before: ${fix.before}\n`;
+    report += `  After:  ${fix.after}\n`;
+  }
+
+  return report;
+};
+
+export const generateMarkdownReport = (diagnostics: Diagnostic[], projectName: string): string => {
+  const sections = groupDiagnosticsByCategory(diagnostics);
+  const errorCount = diagnostics.filter((d) => d.severity === "error").length;
+  const warningCount = diagnostics.filter((d) => d.severity === "warning").length;
+
+  let report = `# Vercel Doctor Report: ${projectName}\n\n`;
+  report += `**Generated:** ${new Date().toISOString()}\n\n`;
+  report += `## Summary\n\n`;
+  report += `- **Total Issues:** ${diagnostics.length}\n`;
+  report += `- **Errors:** ${errorCount}\n`;
+  report += `- **Warnings:** ${warningCount}\n\n`;
+
+  if (diagnostics.length === 0) {
+    report += "✅ No issues found! Your project follows Vercel best practices.\n";
+    return report;
+  }
+
+  for (const section of sections) {
+    report += `## ${section.title}\n\n`;
+    report += `> ${section.description}\n\n`;
+    report += `**Impact:** ${section.impact}\n\n`;
+
+    for (const diagnostic of section.diagnostics) {
+      const icon = diagnostic.severity === "error" ? "❌" : "⚠️";
+      const location = diagnostic.line > 0 ? `:${diagnostic.line}` : "";
+      report += `### ${icon} ${diagnostic.message}\n\n`;
+      report += `- **File:** \`${diagnostic.filePath}${location}\`\n`;
+      report += `- **Rule:** \`${diagnostic.plugin}/${diagnostic.rule}\`\n`;
+      if (diagnostic.help) {
+        report += `- **Suggestion:** ${diagnostic.help}\n`;
+      }
+
+      const fix = RULE_FIX_STRATEGIES[diagnostic.rule];
+      if (fix) {
+        report += `\n<details>\n<summary>🤖 AI Fix Prompt (Click to expand)</summary>\n\n`;
+        report += "\`\`\`\n";
+        report += generateAIPrompt({
+          rule: diagnostic.rule,
+          issue: diagnostic.message,
+          filePath: diagnostic.filePath,
+          line: diagnostic.line,
+          severity: diagnostic.severity,
+          fixStrategy: diagnostic.help,
+        });
+        report += "\n\`\`\`\n\n</details>\n";
+      }
+
+      report += "\n";
+    }
+  }
+
+  return report;
+};

--- a/packages/vercel-doctor/src/utils/generate-report.ts
+++ b/packages/vercel-doctor/src/utils/generate-report.ts
@@ -212,8 +212,9 @@ const generateAIPrompt = (context: AIPromptContext): string => {
 **Fix Strategy:**
 ${fixStrategy?.explanation || context.fixStrategy}
 
-${fixStrategy
-      ? `**Example:**
+${
+  fixStrategy
+    ? `**Example:**
 \`\`\`
 // Before:
 ${fixStrategy.before}
@@ -221,8 +222,8 @@ ${fixStrategy.before}
 // After:
 ${fixStrategy.after}
 \`\`\``
-      : ""
-    }
+    : ""
+}
 
 Instructions:
 1. Locate the issue in the specified file
@@ -366,7 +367,6 @@ export const generateAIPrompts = (diagnostics: Diagnostic[]): AIPromptEntry[] =>
     };
   });
 };
-
 
 export const generateMarkdownReport = (
   diagnostics: Diagnostic[],

--- a/packages/vercel-doctor/tests/generate-report.test.ts
+++ b/packages/vercel-doctor/tests/generate-report.test.ts
@@ -1,168 +1,171 @@
 import { describe, expect, it } from "vitest";
 import plugin from "../src/plugin/index.js";
 import {
-    RULE_FIX_STRATEGIES,
-    generateAIPrompts,
-    generateAIPromptsMarkdown,
-    generateHumanReadableReport,
-    generateMarkdownReport,
-    groupDiagnosticsByCategory,
+  RULE_FIX_STRATEGIES,
+  generateAIPrompts,
+  generateAIPromptsMarkdown,
+  generateHumanReadableReport,
+  generateMarkdownReport,
+  groupDiagnosticsByCategory,
 } from "../src/utils/generate-report.js";
 import type { Diagnostic } from "../src/types.js";
 
 // ─── Fixtures ────────────────────────────────────────────────────────────────
 
 const makeDiagnostic = (overrides: Partial<Diagnostic> = {}): Diagnostic => ({
-    filePath: "/app/page.tsx",
-    plugin: "vercel",
-    rule: "vercel-no-force-dynamic",
-    severity: "error",
-    message: "Test message",
-    help: "Test help",
-    line: 1,
-    column: 1,
-    category: "Vercel",
-    ...overrides,
+  filePath: "/app/page.tsx",
+  plugin: "vercel",
+  rule: "vercel-no-force-dynamic",
+  severity: "error",
+  message: "Test message",
+  help: "Test help",
+  line: 1,
+  column: 1,
+  category: "Vercel",
+  ...overrides,
 });
 
 // ─── #5: RULE_FIX_STRATEGIES drift check ─────────────────────────────────────
 
 describe("RULE_FIX_STRATEGIES", () => {
-    it("all keys are registered in the live plugin or oxlint rule registry", () => {
-        // Plugin rules (js-performance, nextjs, server)
-        const registeredPluginRules = new Set(Object.keys(plugin.rules));
-        // Vercel checks use string rule IDs — collect from RULE_FIX_STRATEGIES itself
-        // and cross-reference against what we know is registered in run-vercel-checks.
-        // The invariant: every key in RULE_FIX_STRATEGIES must be a known rule ID.
-        // We detect obvious drift by checking that no key is empty or obviously malformed.
-        for (const key of Object.keys(RULE_FIX_STRATEGIES)) {
-            expect(key).toMatch(/^[a-z][a-z0-9-]+$/);
-        }
-        // Plugin rule keys in RULE_FIX_STRATEGIES must be a subset of registered plugin rules
-        const pluginRulesInStrategies = Object.keys(RULE_FIX_STRATEGIES).filter((k) =>
-            registeredPluginRules.has(k),
-        );
-        // Every plugin rule key found in strategies must still exist in the plugin
-        for (const key of pluginRulesInStrategies) {
-            expect(registeredPluginRules.has(key)).toBe(true);
-        }
-    });
+  it("all keys are registered in the live plugin or oxlint rule registry", () => {
+    // Plugin rules (js-performance, nextjs, server)
+    const registeredPluginRules = new Set(Object.keys(plugin.rules));
+    // Vercel checks use string rule IDs — collect from RULE_FIX_STRATEGIES itself
+    // and cross-reference against what we know is registered in run-vercel-checks.
+    // The invariant: every key in RULE_FIX_STRATEGIES must be a known rule ID.
+    // We detect obvious drift by checking that no key is empty or obviously malformed.
+    for (const key of Object.keys(RULE_FIX_STRATEGIES)) {
+      expect(key).toMatch(/^[a-z][a-z0-9-]+$/);
+    }
+    // Plugin rule keys in RULE_FIX_STRATEGIES must be a subset of registered plugin rules
+    const pluginRulesInStrategies = Object.keys(RULE_FIX_STRATEGIES).filter((k) =>
+      registeredPluginRules.has(k),
+    );
+    // Every plugin rule key found in strategies must still exist in the plugin
+    for (const key of pluginRulesInStrategies) {
+      expect(registeredPluginRules.has(key)).toBe(true);
+    }
+  });
 });
 
 // ─── #8: groupDiagnosticsByCategory ─────────────────────────────────────────
 
 describe("groupDiagnosticsByCategory", () => {
-    it("groups diagnostics by category", () => {
-        const diagnostics = [
-            makeDiagnostic({ category: "Vercel" }),
-            makeDiagnostic({ category: "Vercel" }),
-            makeDiagnostic({ category: "Next.js", rule: "nextjs-link-prefetch-default" }),
-        ];
-        const sections = groupDiagnosticsByCategory(diagnostics);
-        expect(sections).toHaveLength(2);
-        const vercelSection = sections.find((s) => s.title === "Vercel");
-        expect(vercelSection?.diagnostics).toHaveLength(2);
-        const nextSection = sections.find((s) => s.title === "Next.js");
-        expect(nextSection?.diagnostics).toHaveLength(1);
-    });
+  it("groups diagnostics by category", () => {
+    const diagnostics = [
+      makeDiagnostic({ category: "Vercel" }),
+      makeDiagnostic({ category: "Vercel" }),
+      makeDiagnostic({ category: "Next.js", rule: "nextjs-link-prefetch-default" }),
+    ];
+    const sections = groupDiagnosticsByCategory(diagnostics);
+    expect(sections).toHaveLength(2);
+    const vercelSection = sections.find((s) => s.title === "Vercel");
+    expect(vercelSection?.diagnostics).toHaveLength(2);
+    const nextSection = sections.find((s) => s.title === "Next.js");
+    expect(nextSection?.diagnostics).toHaveLength(1);
+  });
 
-    it("falls back to known descriptions for known categories", () => {
-        const sections = groupDiagnosticsByCategory([makeDiagnostic({ category: "Performance" })]);
-        expect(sections[0].description).toContain("runtime performance");
-    });
+  it("falls back to known descriptions for known categories", () => {
+    const sections = groupDiagnosticsByCategory([makeDiagnostic({ category: "Performance" })]);
+    expect(sections[0].description).toContain("runtime performance");
+  });
 
-    it("uses generic description for unknown categories", () => {
-        const sections = groupDiagnosticsByCategory([
-            makeDiagnostic({ category: "UnknownCategory" }),
-        ]);
-        expect(sections[0].description).toBe("General code quality issues");
-    });
+  it("uses generic description for unknown categories", () => {
+    const sections = groupDiagnosticsByCategory([makeDiagnostic({ category: "UnknownCategory" })]);
+    expect(sections[0].description).toBe("General code quality issues");
+  });
 
-    it("returns empty array for empty input", () => {
-        expect(groupDiagnosticsByCategory([])).toEqual([]);
-    });
+  it("returns empty array for empty input", () => {
+    expect(groupDiagnosticsByCategory([])).toEqual([]);
+  });
 });
 
 // ─── #8 + #10: generateAIPrompts ─────────────────────────────────────────────
 
 describe("generateAIPrompts", () => {
-    it("returns an array (not a Map)", () => {
-        const result = generateAIPrompts([makeDiagnostic()]);
-        expect(Array.isArray(result)).toBe(true);
-    });
+  it("returns an array (not a Map)", () => {
+    const result = generateAIPrompts([makeDiagnostic()]);
+    expect(Array.isArray(result)).toBe(true);
+  });
 
-    it("produces one entry per diagnostic (no key collision)", () => {
-        // Two diagnostics with the same rule but different files — both must be preserved
-        const diagnostics = [
-            makeDiagnostic({ filePath: "/app/page.tsx", line: 1 }),
-            makeDiagnostic({ filePath: "/app/page.tsx", line: 1 }), // same key as above
-            makeDiagnostic({ filePath: "/app/layout.tsx", line: 5 }),
-        ];
-        const result = generateAIPrompts(diagnostics);
-        // All three entries preserved — no silent overwrite
-        expect(result).toHaveLength(3);
-    });
+  it("produces one entry per diagnostic (no key collision)", () => {
+    // Two diagnostics with the same rule but different files — both must be preserved
+    const diagnostics = [
+      makeDiagnostic({ filePath: "/app/page.tsx", line: 1 }),
+      makeDiagnostic({ filePath: "/app/page.tsx", line: 1 }), // same key as above
+      makeDiagnostic({ filePath: "/app/layout.tsx", line: 5 }),
+    ];
+    const result = generateAIPrompts(diagnostics);
+    // All three entries preserved — no silent overwrite
+    expect(result).toHaveLength(3);
+  });
 
-    it("key format is plugin/rule::filePath:line", () => {
-        const diag = makeDiagnostic({ plugin: "vercel", rule: "vercel-no-force-dynamic", filePath: "/app/page.tsx", line: 42 });
-        const [entry] = generateAIPrompts([diag]);
-        expect(entry.key).toBe("vercel/vercel-no-force-dynamic::/app/page.tsx:42");
+  it("key format is plugin/rule::filePath:line", () => {
+    const diag = makeDiagnostic({
+      plugin: "vercel",
+      rule: "vercel-no-force-dynamic",
+      filePath: "/app/page.tsx",
+      line: 42,
     });
+    const [entry] = generateAIPrompts([diag]);
+    expect(entry.key).toBe("vercel/vercel-no-force-dynamic::/app/page.tsx:42");
+  });
 
-    it("returns empty array for empty input", () => {
-        expect(generateAIPrompts([])).toEqual([]);
-    });
+  it("returns empty array for empty input", () => {
+    expect(generateAIPrompts([])).toEqual([]);
+  });
 });
 
 // ─── #8 + #9: Empty-state and deterministic timestamps ────────────────────────
 
 describe("generateHumanReadableReport", () => {
-    it("returns no-issues message for empty diagnostics", () => {
-        const report = generateHumanReadableReport([]);
-        expect(report).toContain("No Vercel optimization issues found");
-    });
+  it("returns no-issues message for empty diagnostics", () => {
+    const report = generateHumanReadableReport([]);
+    expect(report).toContain("No Vercel optimization issues found");
+  });
 
-    it("includes error and warning counts for non-empty diagnostics", () => {
-        const diagnostics = [
-            makeDiagnostic({ severity: "error" }),
-            makeDiagnostic({ severity: "warning", rule: "vercel-no-no-store-fetch" }),
-        ];
-        const report = generateHumanReadableReport(diagnostics);
-        expect(report).toContain("1 errors, 1 warnings");
-    });
+  it("includes error and warning counts for non-empty diagnostics", () => {
+    const diagnostics = [
+      makeDiagnostic({ severity: "error" }),
+      makeDiagnostic({ severity: "warning", rule: "vercel-no-no-store-fetch" }),
+    ];
+    const report = generateHumanReadableReport(diagnostics);
+    expect(report).toContain("1 errors, 1 warnings");
+  });
 });
 
 describe("generateMarkdownReport", () => {
-    it("returns no-issues block for empty diagnostics", () => {
-        const report = generateMarkdownReport([], "my-project", "2024-01-01T00:00:00.000Z");
-        expect(report).toContain("No issues found");
-    });
+  it("returns no-issues block for empty diagnostics", () => {
+    const report = generateMarkdownReport([], "my-project", "2024-01-01T00:00:00.000Z");
+    expect(report).toContain("No issues found");
+  });
 
-    it("uses the provided timestamp instead of calling Date (deterministic)", () => {
-        const ts = "2024-06-15T12:00:00.000Z";
-        const report = generateMarkdownReport([makeDiagnostic()], "my-project", ts);
-        expect(report).toContain(ts);
-        // Must NOT contain a different runtime timestamp
-        expect(report).not.toContain("2025-");
-        expect(report).not.toContain("2026-");
-    });
+  it("uses the provided timestamp instead of calling Date (deterministic)", () => {
+    const ts = "2024-06-15T12:00:00.000Z";
+    const report = generateMarkdownReport([makeDiagnostic()], "my-project", ts);
+    expect(report).toContain(ts);
+    // Must NOT contain a different runtime timestamp
+    expect(report).not.toContain("2025-");
+    expect(report).not.toContain("2026-");
+  });
 
-    it("includes project name in report header", () => {
-        const report = generateMarkdownReport([makeDiagnostic()], "my-cool-app");
-        expect(report).toContain("my-cool-app");
-    });
+  it("includes project name in report header", () => {
+    const report = generateMarkdownReport([makeDiagnostic()], "my-cool-app");
+    expect(report).toContain("my-cool-app");
+  });
 });
 
 describe("generateAIPromptsMarkdown", () => {
-    it("returns no-fixable-issues message for empty input", () => {
-        const report = generateAIPromptsMarkdown([]);
-        expect(report).toContain("No auto-fixable issues detected");
-    });
+  it("returns no-fixable-issues message for empty input", () => {
+    const report = generateAIPromptsMarkdown([]);
+    expect(report).toContain("No auto-fixable issues detected");
+  });
 
-    it("uses the provided timestamp (deterministic)", () => {
-        const ts = "2024-06-15T12:00:00.000Z";
-        const diag = makeDiagnostic({ rule: "vercel-no-force-dynamic" });
-        const report = generateAIPromptsMarkdown([diag], ts);
-        expect(report).toContain(ts);
-    });
+  it("uses the provided timestamp (deterministic)", () => {
+    const ts = "2024-06-15T12:00:00.000Z";
+    const diag = makeDiagnostic({ rule: "vercel-no-force-dynamic" });
+    const report = generateAIPromptsMarkdown([diag], ts);
+    expect(report).toContain(ts);
+  });
 });

--- a/packages/vercel-doctor/tests/generate-report.test.ts
+++ b/packages/vercel-doctor/tests/generate-report.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest";
+import plugin from "../src/plugin/index.js";
+import {
+    RULE_FIX_STRATEGIES,
+    generateAIPrompts,
+    generateAIPromptsMarkdown,
+    generateHumanReadableReport,
+    generateMarkdownReport,
+    groupDiagnosticsByCategory,
+} from "../src/utils/generate-report.js";
+import type { Diagnostic } from "../src/types.js";
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+const makeDiagnostic = (overrides: Partial<Diagnostic> = {}): Diagnostic => ({
+    filePath: "/app/page.tsx",
+    plugin: "vercel",
+    rule: "vercel-no-force-dynamic",
+    severity: "error",
+    message: "Test message",
+    help: "Test help",
+    line: 1,
+    column: 1,
+    category: "Vercel",
+    ...overrides,
+});
+
+// ─── #5: RULE_FIX_STRATEGIES drift check ─────────────────────────────────────
+
+describe("RULE_FIX_STRATEGIES", () => {
+    it("all keys are registered in the live plugin or oxlint rule registry", () => {
+        // Plugin rules (js-performance, nextjs, server)
+        const registeredPluginRules = new Set(Object.keys(plugin.rules));
+        // Vercel checks use string rule IDs — collect from RULE_FIX_STRATEGIES itself
+        // and cross-reference against what we know is registered in run-vercel-checks.
+        // The invariant: every key in RULE_FIX_STRATEGIES must be a known rule ID.
+        // We detect obvious drift by checking that no key is empty or obviously malformed.
+        for (const key of Object.keys(RULE_FIX_STRATEGIES)) {
+            expect(key).toMatch(/^[a-z][a-z0-9-]+$/);
+        }
+        // Plugin rule keys in RULE_FIX_STRATEGIES must be a subset of registered plugin rules
+        const pluginRulesInStrategies = Object.keys(RULE_FIX_STRATEGIES).filter((k) =>
+            registeredPluginRules.has(k),
+        );
+        // Every plugin rule key found in strategies must still exist in the plugin
+        for (const key of pluginRulesInStrategies) {
+            expect(registeredPluginRules.has(key)).toBe(true);
+        }
+    });
+});
+
+// ─── #8: groupDiagnosticsByCategory ─────────────────────────────────────────
+
+describe("groupDiagnosticsByCategory", () => {
+    it("groups diagnostics by category", () => {
+        const diagnostics = [
+            makeDiagnostic({ category: "Vercel" }),
+            makeDiagnostic({ category: "Vercel" }),
+            makeDiagnostic({ category: "Next.js", rule: "nextjs-link-prefetch-default" }),
+        ];
+        const sections = groupDiagnosticsByCategory(diagnostics);
+        expect(sections).toHaveLength(2);
+        const vercelSection = sections.find((s) => s.title === "Vercel");
+        expect(vercelSection?.diagnostics).toHaveLength(2);
+        const nextSection = sections.find((s) => s.title === "Next.js");
+        expect(nextSection?.diagnostics).toHaveLength(1);
+    });
+
+    it("falls back to known descriptions for known categories", () => {
+        const sections = groupDiagnosticsByCategory([makeDiagnostic({ category: "Performance" })]);
+        expect(sections[0].description).toContain("runtime performance");
+    });
+
+    it("uses generic description for unknown categories", () => {
+        const sections = groupDiagnosticsByCategory([
+            makeDiagnostic({ category: "UnknownCategory" }),
+        ]);
+        expect(sections[0].description).toBe("General code quality issues");
+    });
+
+    it("returns empty array for empty input", () => {
+        expect(groupDiagnosticsByCategory([])).toEqual([]);
+    });
+});
+
+// ─── #8 + #10: generateAIPrompts ─────────────────────────────────────────────
+
+describe("generateAIPrompts", () => {
+    it("returns an array (not a Map)", () => {
+        const result = generateAIPrompts([makeDiagnostic()]);
+        expect(Array.isArray(result)).toBe(true);
+    });
+
+    it("produces one entry per diagnostic (no key collision)", () => {
+        // Two diagnostics with the same rule but different files — both must be preserved
+        const diagnostics = [
+            makeDiagnostic({ filePath: "/app/page.tsx", line: 1 }),
+            makeDiagnostic({ filePath: "/app/page.tsx", line: 1 }), // same key as above
+            makeDiagnostic({ filePath: "/app/layout.tsx", line: 5 }),
+        ];
+        const result = generateAIPrompts(diagnostics);
+        // All three entries preserved — no silent overwrite
+        expect(result).toHaveLength(3);
+    });
+
+    it("key format is plugin/rule::filePath:line", () => {
+        const diag = makeDiagnostic({ plugin: "vercel", rule: "vercel-no-force-dynamic", filePath: "/app/page.tsx", line: 42 });
+        const [entry] = generateAIPrompts([diag]);
+        expect(entry.key).toBe("vercel/vercel-no-force-dynamic::/app/page.tsx:42");
+    });
+
+    it("returns empty array for empty input", () => {
+        expect(generateAIPrompts([])).toEqual([]);
+    });
+});
+
+// ─── #8 + #9: Empty-state and deterministic timestamps ────────────────────────
+
+describe("generateHumanReadableReport", () => {
+    it("returns no-issues message for empty diagnostics", () => {
+        const report = generateHumanReadableReport([]);
+        expect(report).toContain("No Vercel optimization issues found");
+    });
+
+    it("includes error and warning counts for non-empty diagnostics", () => {
+        const diagnostics = [
+            makeDiagnostic({ severity: "error" }),
+            makeDiagnostic({ severity: "warning", rule: "vercel-no-no-store-fetch" }),
+        ];
+        const report = generateHumanReadableReport(diagnostics);
+        expect(report).toContain("1 errors, 1 warnings");
+    });
+});
+
+describe("generateMarkdownReport", () => {
+    it("returns no-issues block for empty diagnostics", () => {
+        const report = generateMarkdownReport([], "my-project", "2024-01-01T00:00:00.000Z");
+        expect(report).toContain("No issues found");
+    });
+
+    it("uses the provided timestamp instead of calling Date (deterministic)", () => {
+        const ts = "2024-06-15T12:00:00.000Z";
+        const report = generateMarkdownReport([makeDiagnostic()], "my-project", ts);
+        expect(report).toContain(ts);
+        // Must NOT contain a different runtime timestamp
+        expect(report).not.toContain("2025-");
+        expect(report).not.toContain("2026-");
+    });
+
+    it("includes project name in report header", () => {
+        const report = generateMarkdownReport([makeDiagnostic()], "my-cool-app");
+        expect(report).toContain("my-cool-app");
+    });
+});
+
+describe("generateAIPromptsMarkdown", () => {
+    it("returns no-fixable-issues message for empty input", () => {
+        const report = generateAIPromptsMarkdown([]);
+        expect(report).toContain("No auto-fixable issues detected");
+    });
+
+    it("uses the provided timestamp (deterministic)", () => {
+        const ts = "2024-06-15T12:00:00.000Z";
+        const diag = makeDiagnostic({ rule: "vercel-no-force-dynamic" });
+        const report = generateAIPromptsMarkdown([diag], ts);
+        expect(report).toContain(ts);
+    });
+});


### PR DESCRIPTION
## Summary
Adds comprehensive report generation and AI prompt export capabilities to vercel-doctor.

## What's New

### Human-Readable Reports
- Categorized output by issue type (Vercel, Performance, Dead Code, Next.js)
- Impact descriptions explaining why issues matter
- Severity-based formatting with icons

### AI Prompt Export
- Export prompts as `.md` (human-readable) or `.json` (automation)
- Copy-paste ready for Cursor, Claude, Windsurf
- Includes before/after code examples

### New CLI Flags
- `--output <format>` - human, json, markdown
- `--report <file>` - write markdown report
- `--ai-prompts <file>` - export AI prompts

## Usage Examples

```bash
# Human-readable console output
npx vercel-doctor . --output human

# Markdown report
npx vercel-doctor . --report report.md

# AI prompts for manual copy-paste
npx vercel-doctor . --ai-prompts fixes.md

# AI prompts for automation
npx vercel-doctor . --ai-prompts fixes.json